### PR TITLE
separate dependency-failure from package-failure

### DIFF
--- a/tools/opam-builder/checkBuild.ml
+++ b/tools/opam-builder/checkBuild.ml
@@ -118,7 +118,7 @@ let compute_solution_checksum st v solution_deps =
           try
             match FileString.read_file result_file with
             | "SUCCESS\n" -> ()
-            | "FAILURE\n" ->
+            | "FAILURE\n" | "DEPFAIL\n" ->
                Printf.eprintf
                  "Compilation disabled because dependency %s failed before\n%!"
                  version_name;
@@ -185,7 +185,7 @@ let really_check_install failures st v only_to_clean
        Printf.fprintf build_oc "disabled:skip:%s\n" v.version_name;
        close_out build_oc;
        close_out log_oc;
-       FileString.write_file result_file "FAILURE\n";
+       FileString.write_file result_file "DEPFAIL\n";
        ()
 
 let check_installable_solution

--- a/tools/opam-builder/checkExport.ml
+++ b/tools/opam-builder/checkExport.ml
@@ -92,10 +92,12 @@ let export st c stats =
                   Printf.fprintf oc "begin-build:true\n%s\nbegin-build:false\n"
                     build_content;
 
-                | "FAILURE\n" ->
+                | ("FAILURE\n" | "DEPFAIL\n") as status ->
                   let log_content = FileString.read_file log_file in
                   let build_content = FileString.read_file build_file in
-                  Printf.fprintf oc "status:failure\n";
+                  if status = "FAILURE\n"
+                  then Printf.fprintf oc "status:failure\n"
+                  else Printf.fprintf oc "status:depfail\n";
                   Printf.fprintf oc "begin-build:true\n%s\nbegin-build:false\n"
                     build_content;
                   Printf.fprintf oc "begin-log:true\n%s\nbegin-log:false\n"

--- a/tools/opam-builder/checkJson.ml
+++ b/tools/opam-builder/checkJson.ml
@@ -45,8 +45,9 @@ let of_commit ~replace_commit_tree c =
         StringMap.iter (fun _ v ->
             let status =
               match v.version_result with
-              | Some true -> "Ok"
-              | Some false -> "Fail"
+              | Some Success -> "Ok"
+              | Some Failure -> "Fail"
+              | Some Depfail -> "DepFail"
               | None ->
                  match v.version_status with
                  | None -> "NotChecked"
@@ -68,8 +69,9 @@ let of_commit ~replace_commit_tree c =
                         "build_result",
                         S (match v.version_result with
                            | None -> "not available"
-                           | Some true -> "Success"
-                           | Some false -> "Failed");
+                           | Some Success -> "Success"
+                           | Some Failure -> "Failed"
+                           | Some Depfail -> "Depfail");
                         "build_log",
                         S (match v.version_log with
                            | None -> "not available"
@@ -138,8 +140,9 @@ let of_commits ~replace_commit_tree filename title cs =
               let _, t = get_version v in
               let state =
                 match v.version_result with
-                | Some true -> "Ok"
-                | Some false -> "Fail"
+                | Some Success -> "Ok"
+                | Some Failure -> "Fail"
+                | Some Depfail -> "Depfail"
                 | None ->
                    match v.version_status with
                    | None -> "NotChecked"

--- a/tools/opam-builder/checkReport.ml
+++ b/tools/opam-builder/checkReport.ml
@@ -64,7 +64,7 @@ let report st c stats =
               try
                 match FileString.read_file result_file with
                 | "SUCCESS\n" -> incr nsuccess_versions
-                | "FAILURE\n" -> incr nfailed_versions
+                | "FAILURE\n" | "DEPFAIL\n" -> incr nfailed_versions
                 | _ -> raise Exit
               with _ ->
                 incr nerror_versions
@@ -129,8 +129,11 @@ let report st c stats =
                 match FileString.read_file result_file with
                 | "SUCCESS\n" ->
                   Printf.fprintf oc "  <td style=\"background-color: green;\"></td>\n";
-                | "FAILURE\n" ->
-                  Printf.fprintf oc "  <td style=\"background-color: orange;\"><a href=\"#%s\">FAILURE</a></td>\n" v.version_name;
+                | ("FAILURE\n" | "DEPFAIL\n") as fail_status ->
+                  let msg =
+                    if fail_status = "FAILURE\n"
+                    then "FAILURE" else "DEPFAIL" in
+                  Printf.fprintf oc "  <td style=\"background-color: orange;\"><a href=\"#%s\">%s</a></td>\n" msg v.version_name;
                 | _ -> raise Exit
               with _ ->
                 Printf.fprintf oc "  <td style=\"background-color: orange;\">???</td>\n";
@@ -170,8 +173,8 @@ let report st c stats =
               let result_file = install_prefix ^ ".result" in
               try
                 match FileString.read_file result_file with
-                | "SUCCESS\n" -> ()
-                | "FAILURE\n" ->
+                | "SUCCESS\n"-> ()
+                | "FAILURE\n" | "DEPFAIL\n" ->
                   version_header p v;
                   Printf.fprintf oc "<pre>%s</pre>"
                     (FileString.read_file build_file);

--- a/tools/opam-builder/checkTypes.ml
+++ b/tools/opam-builder/checkTypes.ml
@@ -78,7 +78,7 @@ open StringCompat
       mutable version_revdeps : version list;
 
       (* only available after build *)
-      mutable version_result : bool option;
+      mutable version_result : version_result option;
       mutable version_build : build_file option;
       mutable version_log : string option;
     }
@@ -100,6 +100,11 @@ open StringCompat
        lint_warnings: (int * string) list;
        lint_errors: (int * string) list;
      }
+
+   and version_result =
+     | Success (* the version built correctly *)
+     | Failure (* the version failed to build *)
+     | Depfail (* a dependency failed to build *)
 
   type commit = {
       check_date : string;

--- a/tools/opam-builder/commandBuild.ml
+++ b/tools/opam-builder/commandBuild.ml
@@ -61,11 +61,15 @@ let build_packages () =
               try
                 match FileString.read_file result_file with
                 | "SUCCESS\n" ->
-                   Some true
+                   Some Success
                 | "FAILURE\n" ->
                    v.version_log <-
                      (try Some (FileString.read_file log_file) with _ -> None);
-                   Some false
+                   Some Failure
+                | "DEPFAIL\n" ->
+                   v.version_log <-
+                     (try Some (FileString.read_file log_file) with _ -> None);
+                   Some Depfail
                 | _ ->
                    let tmp_file = result_file ^ ".tmp" in
                    (try Sys.remove tmp_file with _ -> ());
@@ -104,7 +108,7 @@ after deleting the wrong result files. *)
                         try
                           let vdep = StringMap.find dep c.versions in
                           match vdep.version_result with
-                          | Some true ->
+                          | Some Success ->
                              Printf.eprintf
                                "Inconsistency: %S skipped, but dep %S is ok\n%!"
                                v.version_name vdep.version_name;

--- a/tools/opam-builder/files/opam-builder.css
+++ b/tools/opam-builder/files/opam-builder.css
@@ -1,5 +1,6 @@
 .Ok { background-color: green; }
-.BadDeps { background-color: orange; }
+.BadDeps { background-color: white; }
+.DepFail { background-color: orange; }
 .Fail { background-color: red; }
 
 .page-body {

--- a/tools/opam-builder/files/opam-builder.html
+++ b/tools/opam-builder/files/opam-builder.html
@@ -30,6 +30,7 @@
     <select id='id-select-table-tag' onchange='javascript:select_table_tag()'>
       <option value="" selected>View All</option>
       <option value="Fail">View Failures</option>
+      <option value="DepFail">View Dependency Failures</option>
       <option value="BadDeps">View Bad Dependencies</option>
       <option value="Missing">View Not-Available</option>
     </select>

--- a/tools/opam-builder/files/opam-builder.js
+++ b/tools/opam-builder/files/opam-builder.js
@@ -107,7 +107,7 @@ var table_page = 0;       // position of displayed table
 var table_page_size = initial_page_size;    // min number of displayed entries
 var table_title = "";   // current displayed switch
 var table_search = "";   // global search
-var table_tag = "";      // Ok, Missing, Fail, BadDeps
+var table_tag = "";      // Ok, Missing, Fail, DepFail, BadDeps
 
 var package_json_url = "";
 var package_json = null;


### PR DESCRIPTION
Currently opam-builder considers that any package whose dependencies are *installable* should be buildable, and counts any failure as just a Failure of the package to build. This PR separates two status, Failure, when the package itself fails to build, and DepFail (Dependency Failure), when one of the dependencies failed to build. Separating the two in the web interface really matter if we want to locate the packages that have to be fixed first -- currently I waste time going through Failure that are in fact DepFail, and (for now) require no action on my part.

Fixes #5.